### PR TITLE
Refactor repo link as element

### DIFF
--- a/app/build/bundle.js
+++ b/app/build/bundle.js
@@ -40200,6 +40200,9 @@ var Request = require('./request');
 var RequestOverview = require('./request_overview');
 var Question = require('./question');
 var Results = require('./results');
+var RepoLink = React.createElement('a', {
+    href: 'https://github.com/18F/playbook-in-action/issues',
+}, 'reporting issues and feedback');
 
 
 var Header = React.createClass({displayName: "Header",
@@ -40211,10 +40214,8 @@ var Header = React.createClass({displayName: "Header",
 
 		return (
 			React.createElement("div", null, 
-				React.createElement("div", {className: "container"}, 
-					React.createElement("p", {id: "site-status"}, "Help us improve by reporting issues and feedback ", React.createElement("a", {href: "https://github.com/18F/playbook-in-action/issues"}, "here."))
-				), 
 				React.createElement("div", {className: "col-md-12 header"}, 
+					React.createElement("p", {id: "site-status"}, "Help us improve by ", RepoLink, "."), 
 					React.createElement("h1", null, 
 						React.createElement(IndexLink, {to: "/", style: inheritStyle}, "Playbook in Action")					
 					)

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -18,6 +18,9 @@ var Request = require('./request');
 var RequestOverview = require('./request_overview');
 var Question = require('./question');
 var Results = require('./results');
+var RepoLink = React.createElement('a', {
+    href: 'https://github.com/18F/playbook-in-action/issues',
+}, 'reporting issues and feedback');
 
 
 var Header = React.createClass({
@@ -30,7 +33,7 @@ var Header = React.createClass({
 		return (
 			<div>
 				<div className="col-md-12 header">
-					<p id="site-status">Help us improve by reporting issues and feedback <a href="https://github.com/18F/playbook-in-action/issues">here.</a></p>
+					<p id="site-status">Help us improve by {RepoLink}.</p>
 					<h1>
 						<IndexLink to="/" style={inheritStyle}>Playbook in Action</IndexLink>					
 					</h1>


### PR DESCRIPTION
This PR:
 1. refactors the repository link as an element and
 2. changes the word `here` to something more descriptive in order to improve the user experience for people using screen readers.

Cleanup done while investigating #78 the other day.