### PR TITLE
Update Gulp instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The server expects a `DATABASE_URL` environment variable of the form expected by
 
 To launch the app run `python server.py`. The site will be available at `http://localhost:5000`. To seed the database and delete any old tables run create_tables() (from server.py).
 
-To ensure bundle.js is updated with the changes to any react code you will need to use something like the node package gulp. You can either let it run in a separate terminal tab (just enter `gulp`), or when you start the app run `gulp python server.py`.
+To ensure bundle.js is updated with the changes to any React code, you will need to use something like the node package Gulp. Once you have it [installed](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md), leave it running in a separate Terminal tab: just change to the `app` directory (`cd app`) and run `gulp`.
 
 ### Public domain
 


### PR DESCRIPTION
* Added information about installation and which directory you'll need to be in to run Gulp.
* Deleted the oneline version due to errors. (It throws a `No gulpfile found` error when run from the root directory. When I cd to the `app` directory and then try `gulp python ../server.py`, I get the error  `Task 'python' is not in your gulpfile`.)