### PR TITLE
Revert "Add initial .cfignore to minimize deployment size"

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,4 +1,0 @@
-app/node_modules/
-app/bower_components/
-.DS_Store
-venv/


### PR DESCRIPTION
Reverts 18F/playbook-in-action#116

I am reverting this for now, because we need to take in consideration how this will impact the buildpacks.