### PR TITLE
remove double dash from argument flag

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -24,5 +24,5 @@ else
   exit
 fi
 
-cf login --a $API --u $CF_USERNAME --p $CF_PASSWORD --o $ORG -s $SPACE
+cf login -a $API -u $CF_USERNAME -p $CF_PASSWORD -o $ORG -s $SPACE
 cf zero-downtime-push $NAME -f $MANIFEST


### PR DESCRIPTION
cf cli uses single dash for short hand (single character flags).